### PR TITLE
Fixes NoMethodError for add_bundler_dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,3 @@
 source :rubygems
 
-gem 'rack'
-
-group :development do
-  gem 'rake'
-end
-
-group :test do
-  gem 'shoulda'
-end
+gemspec

--- a/url_mount.gemspec
+++ b/url_mount.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.5}
   s.summary = %q{Universal mounting points for rack applications}
 
-  s.add_bundler_dependencies
+  s.add_dependency  'rack'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'shoulda'
+  
 end
 


### PR DESCRIPTION
/usr/local/lib/ruby/1.9.1/rubygems/specification.rb:538:in `method_missing': undefined method`add_bundler_dependencies' for #<Gem::Specification name=url_mount version=0.2.1> (NoMethodError)
