### PR TITLE
Add support for http_router splat variables

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,37 @@
---- 
-dependencies: 
-  rake: 
-    group: 
-    - :development
-    version: ">= 0"
-  shoulda: 
-    group: 
-    - :test
-    version: ">= 0"
-  rack: 
-    group: 
-    - :default
-    version: ">= 0"
-specs: 
-- rake: 
-    version: 0.8.7
-- rack: 
-    version: 1.1.0
-- shoulda: 
-    version: 2.10.3
-hash: 20813f28addb840e72440df2793e52ace4717691
-sources: 
-- Rubygems: 
-    uri: http://gemcutter.org
+PATH
+  remote: .
+  specs:
+    url_mount (0.2.1)
+      rack
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activesupport (4.2.5.2)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.4)
+    rack (1.6.4)
+    rake (10.5.0)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.2.1)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  shoulda
+  url_mount!

--- a/README.textile
+++ b/README.textile
@@ -42,8 +42,12 @@ mount.url(:bar => "something") == "/foo/something"
 mount.url #=> Raises UrlMount::Ungeneratable because a required variable was not found
 mount.required_variables == [:bar]
 
-# UrlMount::Ungeneratable raised when a route cannot be generated without options
-no_mount = UrlMount.new("/foo/:bar") # fails because the mount point cannot be generated with no options
+# Mount Point including splat variables
+mount = UrlMount.new("/foo/*bar")
+mount.url(:bar => ["something", "else"]) == "/foo/something/else"
+mount.url(:bar => 'simple') == "/foo/simple"
+mount.url #=> Raises UrlMount::Ungeneratable because a required variable was not found
+mount.required_variables == [:bar]
 
 # Mount Point including optional variables
 mount = UrlMount.new("/foo/:bar(/:baz)", :bar => "bar")

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rake'
 
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
+  test.libs << 'test'
   test.pattern = 'test/**/test_*.rb'
   test.verbose = true
 end
@@ -23,7 +23,7 @@ end
 
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/url_mount.rb
+++ b/lib/url_mount.rb
@@ -127,6 +127,12 @@ class UrlMount
         else
           buffer << ')'
         end
+      when /^\*(.*)/
+        if stack.empty?
+          @local_segments << Segment::Splat.new($1, options)
+        else
+          buffer << segment
+        end
       when /^\:(.*)/
         if stack.empty?
           @local_segments << Segment::Variable.new($1, options)
@@ -174,6 +180,14 @@ class UrlMount
       def to_s(opts = {})
         item = opts.delete(name) || @options[name]
         item.respond_to?(:call) ? item.call : item
+      end
+    end
+
+    class Splat < Variable
+      def to_s(opts = {})
+        item = opts.delete(name) || @options[name]
+        item = item.join('/') if item.is_a? Array
+        super({ name => item })
       end
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,11 +1,8 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
 require 'shoulda'
 require 'rack'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'url_mount'
-
-class Test::Unit::TestCase
-end

--- a/test/test_url_mount.rb
+++ b/test/test_url_mount.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestUrlMount < Test::Unit::TestCase
+class TestUrlMount < Minitest::Test
   should "initialize with a path and options" do
     u = UrlMount.new("/some/path", :some => "options")
     assert_equal u.raw_path, "/some/path"
@@ -71,7 +71,7 @@ class TestUrlMount < Test::Unit::TestCase
       assert_equal [:bar, :baz], u.optional_variables
     end
 
-    should "calculate optional variables when there are some" do
+    should "generate url with optional variables when there are some" do
       u = UrlMount.new("/foo(/:bar(/:baz))")
       assert_equal "/foo/gary", u.url(:bar => "gary")
     end

--- a/test/test_url_mount.rb
+++ b/test/test_url_mount.rb
@@ -228,4 +228,40 @@ class TestUrlMount < Minitest::Test
       assert_equal "/foo/here_is_my_bar", u.url(env)
     end
   end
+
+  context 'splat variables' do
+    should 'be usable as required variables' do
+      u = UrlMount.new('/foo/*bar')
+      assert_equal [:bar], u.required_variables
+      assert_equal( {:required => [:bar], :optional => []}, u.variables )
+    end
+
+    should 'be usable as optional variables' do
+      u = UrlMount.new('/foo/(*bar)')
+      assert_equal [:bar], u.optional_variables
+      assert_equal( {:required => [], :optional => [:bar]}, u.variables )
+      assert_equal '/foo', u.url
+    end
+
+    should 'respect default values' do
+      u = UrlMount.new('/foo/*bar', bar: 'bar')
+      assert_equal '/foo/bar', u.url
+    end
+
+    should 'accept strings as value' do
+      u = UrlMount.new('/foo/*bar')
+      assert_equal '/foo/homer', u.url(bar: 'homer')
+    end
+
+    should 'accept arrays as value' do
+      u = UrlMount.new('/foo/*bar', bar: %w{bar baz})
+      assert_equal '/foo/bar/baz', u.url
+      assert_equal '/foo/bar/homer', u.url(bar: %w{bar homer})
+    end
+
+    should 'be usable alongside regular variables' do
+      u = UrlMount.new('/foo/:bar/*baz')
+      assert_equal '/foo/new_bar/some/homer', u.url(bar: 'new_bar', baz: %w{some homer})
+    end
+  end
 end


### PR DESCRIPTION
This allows for splat variables in the same style as http_router to be used in url_mount.  Since http_router ouputs splat variables as arrays in params, I thought it made sense for url_mount to accept arrays as their values.

This was all done with Ruby 2.1.5, so I had to fiddle with some of the test machinery to get everything working.
