### PR TITLE
Remove unused method definition (fix warning)

### DIFF
--- a/lib/url_mount.rb
+++ b/lib/url_mount.rb
@@ -24,10 +24,6 @@ class UrlMount
     @local_segments || parse_local_segments
   end
 
-  def variables
-    required_variables + local_variables
-  end
-
   def required_variables
     @required_variables ||= begin
       required_variable_segments.map{|s| s.name}


### PR DESCRIPTION
This method is immediately redefined below, so this implementation does absolutely nothing except cause a Ruby warning if they're enabled.